### PR TITLE
feat: Adjust modal text size and wrapping on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,6 +402,16 @@
             :root {
                 --scroll-padding: 140px;
             }
+            .modal-text-content {
+                padding: 2rem;
+            }
+            .modal-text-content h3 {
+                font-size: 1.8rem;
+                overflow-wrap: break-word;
+            }
+            .modal-text-content p {
+                font-size: 1rem;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
Reduces the font size of the header and paragraph in the activity modal for screen widths up to 768px.

- The header (h3) font size is reduced from 2.5rem to 1.8rem.
- The paragraph (p) font size is reduced from 1.1rem to 1rem.
- Added 'overflow-wrap: break-word' to the modal header to prevent long words from causing horizontal scrolling.
- Reduced modal content padding on mobile for better spacing.